### PR TITLE
Unwrap multiple objects in one call

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "sanitizer",
-  "version": "0.1.0",
+  "name": "fxos-sanitizer",
+  "version": "0.1.1",
   "homepage": "https://github.com/fxos-eng/sanitizer",
   "authors": [
     "FxOS Developers <dev-gaia@lists.mozilla.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "sanitizer",
-  "version": "0.1.0",
+  "name": "fxos-sanitizer",
+  "version": "0.1.1",
   "description": "A simple library to help you escape HTML using template strings",
   "main": "sanitizer.js",
   "scripts": {},

--- a/sanitizer.js
+++ b/sanitizer.js
@@ -74,8 +74,11 @@
      * Unwrap safe HTML created by createSafeHTML or a custom replacement that
      * underwent security review.
      */
-    unwrapSafeHTML: function (htmlObject) {
-      return htmlObject.__html;
+    unwrapSafeHTML: function (...htmlObjects) {
+      var markupList= htmlObjects.map(function(obj) {
+        return  obj.__html;
+      });
+      return markupList.join("");
     }
   };
 


### PR DESCRIPTION
This patch allows unwrapping multiple safe objects in just one call, e.g.,

``` js
// currently allowed:
foo.innerHTML = unwrapSafeHTML(foo);
// now also allowed
foo.innerHTML = unwrapSafeHTML(foo, bar);
```

@justindarc, can you give this a quick review?

I suppose we will want to have tests running for this library very soon, so we can move faster :-)
