### PR TITLE
Replacing spread operators by their es5 equivalent

### DIFF
--- a/sanitizer.js
+++ b/sanitizer.js
@@ -43,13 +43,14 @@
     /**
      * Escapes HTML for all values in a tagged template string.
      */
-    escapeHTML: function (strings, ...values) {
+    escapeHTML: function (strings) {
       var result = '';
 
       for (var i = 0; i < strings.length; i++) {
         result += strings[i];
+        var value = arguments[i + 1] || '';
         if (i < values.length) {
-          result += String(values[i]).replace(Sanitizer._entity,
+          result += String(value).replace(Sanitizer._entity,
             Sanitizer.getEntity);
         }
       }
@@ -59,8 +60,15 @@
     /**
      * Escapes HTML and returns a wrapped object to be used during DOM insertion
      */
-    createSafeHTML: function (strings, ...values) {
-      var escaped = Sanitizer.escapeHTML(strings, ...values);
+    createSafeHTML: function (strings) {
+      var _len = arguments.length;
+      var values = new Array(_len > 1 ? _len - 1 : 0);
+      for (var _key = 1; _key < _len; _key++) {
+        values[_key - 1] = arguments[_key];
+      }
+
+      var escaped = Sanitizer.escapeHTML.apply(Sanitizer,
+        [strings].concat(values));
       return {
         __html: escaped,
         toString: function () {
@@ -74,7 +82,13 @@
      * Unwrap safe HTML created by createSafeHTML or a custom replacement that
      * underwent security review.
      */
-    unwrapSafeHTML: function (...htmlObjects) {
+    unwrapSafeHTML: function () {
+      var _len = arguments.length;
+      var htmlObjects = new Array(_len);
+      for (var _key = 0; _key < _len; _key++) {
+        htmlObjects[_key] = arguments[_key];
+      }
+
       var markupList = htmlObjects.map(function(obj) {
         return obj.__html;
       });


### PR DESCRIPTION
Sanitizer uses spread operators and requires a JavaScript environment where they are supported.
In [MVC](https://github.com/fxos-eng/mvc), the transpilation happens before the concatenation with the polyfills (which include Sanitizer). So if we want MVC to runs on es5 only environments (old browsers, Cordova...), we must ensure that Sanitizer is es5 compliant.
